### PR TITLE
Scope Test Dependencies, so they don't get added to production classpath

### DIFF
--- a/ff4j-spring-boot-autoconfigure/pom.xml
+++ b/ff4j-spring-boot-autoconfigure/pom.xml
@@ -59,10 +59,12 @@
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-test</artifactId>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
     </dependency>
   </dependencies>
   <build>

--- a/ff4j-spring-boot-web-api/pom.xml
+++ b/ff4j-spring-boot-web-api/pom.xml
@@ -67,26 +67,27 @@
     <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.skyscreamer</groupId>
       <artifactId>jsonassert</artifactId>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>info.cukes</groupId>
       <artifactId>cucumber-junit</artifactId>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>info.cukes</groupId>
       <artifactId>cucumber-spring</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.easymock</groupId>
-      <artifactId>easymock</artifactId>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-test</artifactId>
+      <scope>test</scope>
     </dependency>
   </dependencies>
   <build>

--- a/ff4j-spring-services/pom.xml
+++ b/ff4j-spring-services/pom.xml
@@ -59,22 +59,27 @@
     <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.skyscreamer</groupId>
       <artifactId>jsonassert</artifactId>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.easymock</groupId>
       <artifactId>easymock</artifactId>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-test</artifactId>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.meanbean</groupId>
       <artifactId>meanbean</artifactId>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>info.cukes</groupId>

--- a/ff4j-spring-services/pom.xml
+++ b/ff4j-spring-services/pom.xml
@@ -67,11 +67,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.easymock</groupId>
-      <artifactId>easymock</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-test</artifactId>
       <scope>test</scope>

--- a/pom.xml
+++ b/pom.xml
@@ -78,7 +78,6 @@
     <gson.version>2.2.4</gson.version>
     <assertj.version>3.2.0</assertj.version>
     <jsonassert.version>1.5.0</jsonassert.version>
-    <easymock.version>4.3</easymock.version>
     <swagger.version>3.0.0</swagger.version>
     <springdoc-openapi-ui.version>1.6.6</springdoc-openapi-ui.version>
     <jacoco.version>0.8.7</jacoco.version>
@@ -179,12 +178,6 @@
         <groupId>org.skyscreamer</groupId>
         <artifactId>jsonassert</artifactId>
         <version>${jsonassert.version}</version>
-        <scope>test</scope>
-      </dependency>
-      <dependency>
-        <groupId>org.easymock</groupId>
-        <artifactId>easymock</artifactId>
-        <version>${easymock.version}</version>
         <scope>test</scope>
       </dependency>
       <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -513,6 +513,7 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-javadoc-plugin</artifactId>
+            <version>${version.maven.plugin.javadoc}</version>
             <configuration>
               <additionalparam>-Xdoclint:none</additionalparam>
             </configuration>


### PR DESCRIPTION
Since the test dependencies aren't currently scoped, they are added as transitive dependencies when you use the `ff4j-spring-boot-starter`.